### PR TITLE
Add script for checking typescript types on pull request

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -27,3 +27,5 @@ jobs:
         run: npm run eslint
       - name: stylelint
         run: npm run stylelint
+      - name: typecheck
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "./build.js",
     "eslint": "eslint src/",
     "eslint:fix": "eslint --fix src/",
+    "typecheck": "./ts-check.js",
     "stylelint": "stylelint src/*{.css,scss}",
     "stylelint:fix": "stylelint --fix src/*{.css,scss}"
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -44,8 +44,12 @@ export const Application = () => {
 
     useEffect(() => {
         const updateSuperuserValue = () => setSuperuserValue(superuser.allowed);
+        // @ts-expect-error cockpit doesn't provide proper typing for superuser
+        // so for now we have to just ignore it.
         superuser.addEventListener("changed", updateSuperuserValue);
 
+        // @ts-expect-error cockpit doesn't provide proper typing for superuser
+        // so for now we have to just ignore it.
         return () => superuser.removeEventListener("changed", updateSuperuserValue);
     }, [setSuperuserValue]);
 
@@ -90,7 +94,8 @@ const RepoCard = () => {
 
                 if (newHash !== reposHash) {
                     setReposHash(newHash);
-                    setReposChanged(reposChanged + 1);
+                    if (setReposChanged)
+                        setReposChanged((reposChanged || 0) + 1);
                 }
             });
         }, 1000);

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -48,12 +48,20 @@ interface InvalidRefresh {
 
 export type RefreshError = UknownRefresh | LockedRefresh | UntrustedRefresh | InvalidRefresh;
 
+// Return type for cockpit.spawn where options include {err: "message"}
+// Cockpit uses Spawn typescript type even though it doesn't always adhere to
+// the API definitions so we need to build our own (slightly hacky) type
+export interface MessageSpawn extends Omit<Spawn<string>, "then" | "catch"> {
+    then: (funfilled?: (value: string) => void) => MessageSpawn;
+    catch: (onreject?: (error: string, reason: string) => void) => MessageSpawn;
+}
+
 interface Backend {
   getRepos(): Promise<Repo[]>,
   addRepo(repo: Repo): Promise<string>
-  deleteRepo(repo: Repo): Promise<string>
+  deleteRepo(repo: Repo): MessageSpawn
   modifyRepo(repo: Repo): Promise<string>
-  refreshRepo(repo: Repo | null, importKeys?: boolean): Spawn<string>
+  refreshRepo(repo: Repo | null, importKeys?: boolean): MessageSpawn
   getReposHash(): Spawn<string>
   parseError(error: string): RefreshError
   getErrorMsg(error: RefreshError): React.ReactNode

--- a/src/backends/zypp.tsx
+++ b/src/backends/zypp.tsx
@@ -1,13 +1,13 @@
 import cockpit, { Spawn } from "cockpit";
 import React from "react";
 
-import { Backend, RefreshError, Repo } from "./backend";
+import { Backend, MessageSpawn, RefreshError, Repo } from "./backend";
 
 const _ = cockpit.gettext;
 
 export class Zypp implements Backend {
-    deleteRepo(repo: Repo): Promise<string> {
-        return cockpit.spawn(["zypper", "--xmlout", "removerepo", repo.index.toString()], { superuser: "require", err: "message" });
+    deleteRepo(repo: Repo): MessageSpawn {
+        return cockpit.spawn(["zypper", "--xmlout", "removerepo", repo.index.toString()], { superuser: "require", err: "message" }) as MessageSpawn;
     }
 
     async getRepos(): Promise<Repo[]> {
@@ -79,7 +79,7 @@ export class Zypp implements Backend {
         return cockpit.spawn(["zypper", "modifyrepo", ...args, repo.index.toString()], { superuser: "require" });
     }
 
-    refreshRepo(repo: Repo | null, importKeys?: boolean): Spawn<string> {
+    refreshRepo(repo: Repo | null, importKeys?: boolean): MessageSpawn {
         let refArgs: string[] = [];
         let zypArgs: string[] = [];
         // if there's no repos defined, all will be refreshed
@@ -90,7 +90,7 @@ export class Zypp implements Backend {
             zypArgs = ["--gpg-auto-import-keys"];
         }
 
-        return cockpit.spawn(["zypper", "--xmlout", ...zypArgs, "refresh", "-f", ...refArgs], { superuser: "require", err: "message" });
+        return cockpit.spawn(["zypper", "--xmlout", ...zypArgs, "refresh", "-f", ...refArgs], { superuser: "require", err: "message" }) as MessageSpawn;
     }
 
     getReposHash(): Spawn<string> {
@@ -138,7 +138,7 @@ export class Zypp implements Backend {
         }
 
         if (error.includes("is blocking zypper")) {
-            return { err: "locked", message: doc.documentElement.querySelector("message[type*='info']").textContent || "" };
+            return { err: "locked", message: doc.documentElement.querySelector("message[type*='info']")!.textContent || "" };
         }
 
         return { err: "unknown" };

--- a/src/components/repo_refresh.tsx
+++ b/src/components/repo_refresh.tsx
@@ -1,9 +1,9 @@
 import React, { Dispatch } from "react";
 import { Button, Modal, ModalFooter, ModalHeader } from "@patternfly/react-core";
 import { useDialogs } from "dialogs";
-import { Backend, RefreshError } from "../backends/backend";
+import { Backend, MessageSpawn, RefreshError } from "../backends/backend";
 
-import cockpit, { Spawn } from "cockpit.js";
+import cockpit from "cockpit.js";
 import { EmptyStatePanel } from "cockpit-components-empty-state";
 
 const _ = cockpit.gettext;
@@ -30,8 +30,8 @@ const ErrorFooter = ({
 }: {
     backend: Backend,
     error: RefreshError,
-    refreshing: Spawn<string> | null
-    setRefreshing: Dispatch<Spawn<string> | null>,
+    refreshing: MessageSpawn | null
+    setRefreshing: Dispatch<MessageSpawn | null>,
     setLoading: () => void,
     onLoaded: (err: RefreshError | null) => void
 }) => {
@@ -83,7 +83,7 @@ const ErrorFooter = ({
 const RefreshDialog = ({ backend }: { backend: Backend }) => {
     const Dialogs = useDialogs();
     const [refreshing, setRefreshing] = React.useState(true);
-    const [refreshProcess, setRefreshProcess] = React.useState<Spawn<string> | null>(null);
+    const [refreshProcess, setRefreshProcess] = React.useState<MessageSpawn | null>(null);
     const [error, setError] = React.useState<RefreshError | null>(null);
 
     React.useEffect(() => {

--- a/ts-check.js
+++ b/ts-check.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import * as ts from "typescript";
+
+// Cannot use __basepath because we have "type": "module" in package.json
+const basepath = process.argv[1].slice(0, process.argv[1].lastIndexOf('/'));
+const ignorePaths = [`${basepath}/node_modules`, `${basepath}/pkg`];
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+const shouldIgnore = (filePath) => {
+    for (const path of ignorePaths) {
+        if (filePath.startsWith(path))
+            return true;
+    }
+
+    return false;
+}
+
+/**
+ * @param {string[]} fileNames
+ * @param {ts.CompilerOptions} options
+ */
+function checkTypes(fileNames, options) {
+    const program = ts.createProgram(fileNames, options);
+    const emitResult = program.emit();
+    let success = true;
+
+    const allDiagnostics = ts
+        .getPreEmitDiagnostics(program)
+        .concat(emitResult.diagnostics);
+
+    allDiagnostics.forEach(diagnostic => {
+        if (diagnostic.file) {
+            if (shouldIgnore(diagnostic.file.fileName)) {
+                return;
+            }
+            const { line, character } = ts.getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
+            const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+            const fileName = diagnostic.file.fileName.replace(basepath + '/', '');
+            console.log(`${fileName}:${line + 1}:${character + 1}:\n${message}\n`);
+            success = false;
+        } else {
+            console.log("Unknown diagnostic error:");
+            console.log(ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
+            success = false;
+        }
+    });
+
+    const exitCode = success ? 0 : 1;
+    console.log(`Process exiting with code '${exitCode}'.`);
+    process.exit(exitCode);
+}
+
+const { config } = ts.readConfigFile("tsconfig.json", ts.sys.readFile);
+const tsConfig = ts.parseJsonConfigFileContent(config, ts.sys, basepath);
+// Make sure this script never emits anything
+tsConfig.options.noEmit = true
+
+checkTypes(tsConfig.fileNames, tsConfig.options);


### PR DESCRIPTION
The biggest issue with typescript errors was how cockpit handles `Spawn`/`Promises` so I added a slightly hacky way to handle it. I hope it's good enough :tm: