### PR TITLE
build: remove esbuild-common and copy dependencies

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,13 +5,12 @@ import path from 'node:path';
 import process from 'node:process';
 import os from 'node:os';
 
-import copy from 'esbuild-plugin-copy';
+import { sassPlugin } from 'esbuild-sass-plugin';
 
 import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
 import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
 import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin.js';
-import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
 
 const production = process.env.NODE_ENV === 'production';
 const useWasm = os.arch() !== 'x64';
@@ -90,15 +89,25 @@ const context = await esbuild.context({
     target: ['es2020'],
     plugins: [
         cleanPlugin(),
-        // Esbuild will only copy assets that are explicitly imported and used
-        // in the code. This is a problem for index.html and manifest.json which are not imported
-        copy({
-            assets: [
-                { from: ['./src/manifest.json'], to: ['./manifest.json'] },
-                { from: ['./src/index.html'], to: ['./index.html'] },
-            ]
+
+        // Esbuild will only copy assets that are explicitly imported and used in the code.
+        // Copy the other files here.
+        {
+            name: 'copy-assets',
+            setup(build) {
+                build.onEnd(() => {
+                    fs.copyFileSync('./src/manifest.json', './dist/manifest.json');
+                    fs.copyFileSync('./src/index.html', './dist/index.html');
+                });
+            }
+        },
+
+        sassPlugin({
+            loadPaths: [...nodePaths, 'node_modules'],
+            filter: /\.scss/,
+            quietDeps: true,
         }),
-        ...esbuildStylesPlugins,
+
         cockpitPoEsbuildPlugin(),
         ...production ? [cockpitCompressPlugin()] : [],
         cockpitRsyncEsbuildPlugin({ dest: packageJson.name }),


### PR DESCRIPTION
These libraries are no longer supported by upstream, which breaks our local builds downstream

See
https://github.com/cockpit-project/cockpit/commit/3f331895b9fece4b https://github.com/cockpit-project/starter-kit/commit/62c778dc33b863bcd6606958f8f6c7edbcffe619