### PR TITLE
Don't load @patternfly/patternfly/sass-utilities twice

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,4 +1,3 @@
-@use "@patternfly/patternfly/patternfly-addons";
 @use "page.scss";
 
 p {


### PR DESCRIPTION
Both @patternfly/patternfly/patternfly-addons and
patternfly/patternfly-6-cockpit.scss load sass-utilities which causes issues when cockpit tries to configure it.

See more details
https://github.com/cockpit-project/cockpit/commit/f5943d9387f6b8855a50b61239974562e11f5e25